### PR TITLE
CTECH-2239: Add config_keys class so works with fbnsdkutilities

### DIFF
--- a/sdk/finbourne_identity/utilities/config_keys.py
+++ b/sdk/finbourne_identity/utilities/config_keys.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+
+
+class ConfigKeys:
+
+    config_key_path = "config_keys.json"
+
+    @classmethod
+    def get(cls):
+        with open(Path(__file__).parent.joinpath(cls.config_key_path)) as json_file:
+            config_keys = json.load(json_file)
+            return config_keys

--- a/sdk/tests/utilities/test_config_keys.py
+++ b/sdk/tests/utilities/test_config_keys.py
@@ -14,5 +14,5 @@ class TestConfigKeys(TestCase):
 
         # Assert
         self.assertEqual(
-            actual_config_keys, expected_config_keys_subset | actual_config_keys
+            actual_config_keys, {**actual_config_keys, **expected_config_keys_subset}
         )

--- a/sdk/tests/utilities/test_config_keys.py
+++ b/sdk/tests/utilities/test_config_keys.py
@@ -13,4 +13,6 @@ class TestConfigKeys(TestCase):
         actual_config_keys = ConfigKeys().get()
 
         # Assert
-        self.assertDictContainsSubset(expected_config_keys_subset, actual_config_keys)
+        self.assertEqual(
+            actual_config_keys, expected_config_keys_subset | actual_config_keys
+        )

--- a/sdk/tests/utilities/test_config_keys.py
+++ b/sdk/tests/utilities/test_config_keys.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from finbourne_identity.utilities.config_keys import ConfigKeys
+
+
+class TestConfigKeys(TestCase):
+    def test_identity_url_in_config_keys(self):
+        # Arrange
+        expected_config_keys_subset = {
+            "api_url": {"env": "FBN_LUSID_IDENTITY_URL", "config": "identityUrl"}
+        }
+
+        # Act
+        actual_config_keys = ConfigKeys().get()
+
+        # Assert
+        self.assertDictContainsSubset(expected_config_keys_subset, actual_config_keys)


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [] Raised the PR against the `develop` branch

# Description of the PR

Adding config keys class so Api factory in fbnsdkutilities works with this module.